### PR TITLE
add TradeSha encrypt

### DIFF
--- a/spgateway.go
+++ b/spgateway.go
@@ -125,3 +125,14 @@ func (s *Store) InvoiceCheckCode(invoice Invoice) string {
 
 	return s.hashSha256(querys)
 }
+
+// TradeSha return spgateway trade sha 256 encrypt.
+func (s *Store) TradeSha(tradeInfo string) string {
+	querys := fmt.Sprintf("HashKey=%s&%s&HashIV=%s",
+		s.HashKey,
+		tradeInfo,
+		s.HashIV,
+	)
+
+	return s.hashSha256(querys)
+}

--- a/spgateway_test.go
+++ b/spgateway_test.go
@@ -84,3 +84,17 @@ func TestInvoiceCheckCode(t *testing.T) {
 
 	assert.Equal(t, expect, CheckValue)
 }
+
+func TestTradeSha(t *testing.T) {
+	store := New(Config{
+		HashKey: "12345678901234567890123456789012",
+		HashIV:  "1234567890123456",
+	})
+
+	tradeInfo := "ff91c8aa01379e4de621a44e5f11f72e4d25bdb1a18242db6cef9ef07d80b0165e476fd1d9acaa53170272c82d122961e1a0700a7427cfa1cf90db7f6d6593bbc93102a4d4b9b66d9974c13c31a7ab4bba1d4e0790f0cbbbd7ad64c6d3c8012a601ceaa808bff70f94a8efa5a4f984b9d41304ffd879612177c622f75f4214fa"
+
+	tradeSha := store.TradeSha(tradeInfo)
+	expect := "EA0A6CC37F40C1EA5692E7CBB8AE097653DF3E91365E6A9CD7E91312413C7BB8"
+
+	assert.Equal(t, expect, tradeSha)
+}


### PR DESCRIPTION
## 交易資料 SHA256 加密

1. 將交易資料的 AES 加密字串前後加上商店專屬加密 HashKey 與商店專屬加密 HashIV。
2. 將串聯後的字串用 SHA256 壓碼後轉大寫。

## 範例程式:
1. 交易資料 AES 加密字串 ff91c8aa01379e4de621a44e5f11f72e4d25bdb1a18242db6cef9ef07d80b0165e476f d1d9acaa53170272c82d122961e1a0700a7427cfa1cf90db7f6d6593bbc93102a4d4 b9b66d9974c13c31a7ab4bba1d4e0790f0cbbbd7ad64c6d3c8012a601ceaa808bff70 f94a8efa5a4f984b9d41304ffd879612177c622f75f4214fa

2. 前後加上商店專屬的 HashKey 及 HashIV HashKey=12345678901234567890123456789012& ff91c8aa01379e4de621a44e5f11f72e4d25bdb1a18242db6cef9ef07d80b0165e476f d1d9acaa53170272c82d122961e1a0700a7427cfa1cf90db7f6d6593bbc93102a4d4 b9b66d9974c13c31a7ab4bba1d4e0790f0cbbbd7ad64c6d3c8012a601ceaa808bff70 f94a8efa5a4f984b9d41304ffd879612177c622f75f4214fa&HashIV=1234567890123 456

3. 使用 SHA256 壓碼過後並轉大寫 strtoupper(hash("sha256", "上面字串")); 壓碼結果為:
EA0A6CC37F40C1EA5692E7CBB8AE097653DF3E91365E6A9CD7E91312413C7BB8

Signed-off-by: Bo-Yi Wu <appleboy.tw@gmail.com>