### PR TITLE
add AES Encrypt 交易資料 AES 加密

### DIFF
--- a/spgateway.go
+++ b/spgateway.go
@@ -1,6 +1,9 @@
 package spgateway
 
 import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
 	"crypto/sha256"
 	"fmt"
 	"strings"
@@ -135,4 +138,61 @@ func (s *Store) TradeSha(tradeInfo string) string {
 	)
 
 	return s.hashSha256(querys)
+}
+
+// CreateMpgAesEncrypt encrypt trade info data
+func (s *Store) CreateMpgAesEncrypt(tradeInfo interface{}) (string, error) {
+	v, _ := query.Values(tradeInfo)
+	data := []byte(v.Encode())
+	key := []byte(s.HashKey)
+	iv := []byte(s.HashIV)
+
+	ciphertext, err := Encrypt(key, data, iv)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%x", ciphertext), nil
+}
+
+// Encrypt string
+func Encrypt(key, plaintext, iv []byte) ([]byte, error) {
+	plaintext = PKCS5Padding(plaintext, 32)
+	// CBC mode works on blocks so plaintexts may need to be padded to the
+	// next whole block. For an example of such padding, see
+	// https://tools.ietf.org/html/rfc5246#section-6.2.3.2. Here we'll
+	// assume that the plaintext is already of the correct length.
+	if len(plaintext)%aes.BlockSize != 0 {
+		panic("plaintext is not a multiple of the block size")
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		panic(err)
+	}
+
+	// The IV needs to be unique, but not secure. Therefore it's common to
+	// include it at the beginning of the ciphertext.
+	ciphertext := make([]byte, len(plaintext))
+	mode := cipher.NewCBCEncrypter(block, iv)
+	mode.CryptBlocks(ciphertext, plaintext)
+
+	// It's important to remember that ciphertexts must be authenticated
+	// (i.e. by using crypto/hmac) as well as being encrypted in order to
+	// be secure.
+
+	return ciphertext, nil
+}
+
+// PKCS5Padding is described in RFC 5652.
+func PKCS5Padding(src []byte, blockSize int) []byte {
+	padding := blockSize - len(src)%blockSize
+	padtext := bytes.Repeat([]byte{byte(padding)}, padding)
+	return append(src, padtext...)
+}
+
+// PKCS5UnPadding is described in RFC 5652.
+func PKCS5UnPadding(src []byte) []byte {
+	length := len(src)
+	unpadding := int(src[length-1])
+	return src[:(length - unpadding)]
 }

--- a/spgateway.go
+++ b/spgateway.go
@@ -158,16 +158,10 @@ func (s *Store) CreateMpgAesEncrypt(tradeInfo interface{}) (string, error) {
 // Encrypt string
 func Encrypt(key, plaintext, iv []byte) ([]byte, error) {
 	plaintext = PKCS5Padding(plaintext, 32)
-	// CBC mode works on blocks so plaintexts may need to be padded to the
-	// next whole block. For an example of such padding, see
-	// https://tools.ietf.org/html/rfc5246#section-6.2.3.2. Here we'll
-	// assume that the plaintext is already of the correct length.
-	if len(plaintext)%aes.BlockSize != 0 {
-		panic("plaintext is not a multiple of the block size")
-	}
+
 	block, err := aes.NewCipher(key)
 	if err != nil {
-		panic(err)
+		return []byte(""), err
 	}
 
 	// The IV needs to be unique, but not secure. Therefore it's common to

--- a/spgateway_test.go
+++ b/spgateway_test.go
@@ -98,3 +98,36 @@ func TestTradeSha(t *testing.T) {
 
 	assert.Equal(t, expect, tradeSha)
 }
+
+type EncryptCheckValue struct {
+	Amt             string
+	MerchantOrderNo string
+	MerchantID      string
+	TimeStamp       string
+	Version         string
+	ItemDesc        string
+	RespondType     string
+}
+
+func TestMpgAesEncrypt(t *testing.T) {
+	store := New(Config{
+		HashKey: "12345678901234567890123456789012",
+		HashIV:  "1234567890123456",
+	})
+
+	data := EncryptCheckValue{
+		MerchantID:      "3430112",
+		RespondType:     "JSON",
+		TimeStamp:       "1485232229",
+		Version:         "1.4",
+		MerchantOrderNo: "S_1485232229",
+		Amt:             "40",
+		ItemDesc:        "UnitTest",
+	}
+
+	aes, err := store.CreateMpgAesEncrypt(data)
+	expect := "e15b868e4f7dbf086a705fbab052ad13daaf9e8750f7fba46cbb6e3b65c689e7c3645e56c1c91475a868cd61478c75fe494b28bf126b3009be4185cf3fc445ce40f9ad78f9e07af0772ed4c2ac54479d93c57f98b2087ceebc5787094893962d7d34d6b969fbfccda635cba69783fa0a9505c01d2cfe7693ff7652ac46193138"
+
+	assert.NoError(t, err)
+	assert.Equal(t, expect, aes)
+}


### PR DESCRIPTION
# 交易資料 AES 加密

將交易資料透過商店專屬加密 HashKey 與商店專屬加密 HashIV，產生 AES 加密交易資 料。

範例資料:

```
[MerchantID] => 3430112 
[RespondType] => JSON 
[TimeStamp] => 1485232229 
[Version] => 1.4 
[MerchantOrderNo] => S_1485232229 
[Amt] => 40 [ItemDesc] => UnitTest
Key = ‘12345678901234567890123456789012’;
IV = ‘1234567890123456’;
```